### PR TITLE
Add the devcontainer.json file

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "python-template-3-11",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11-bullseye",
+
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "configureZshAsDefaultShell": true,
+      "username": "devcontainer"
+    },
+    "ghcr.io/devcontainers-contrib/features/black:2": {},
+    "ghcr.io/devcontainers-contrib/features/pre-commit:2": {},
+    "ghcr.io/devcontainers-contrib/features/poetry:2": {},
+    "ghcr.io/devcontainers-contrib/features/pylint:2": {},
+    "ghcr.io/devcontainers-contrib/features/flake8:2": {},
+    "ghcr.io/devcontainers-contrib/features/ruff:1":  {},
+  },
+
+  "postCreateCommand": "pip3 install --user --upgrade pip setuptools",
+  "postCreateCommand": "poetry install --no-root --with test,dev",
+  "postCreateCommand": "pre-commit install",
+
+}


### PR DESCRIPTION
- use the `python:3.11-bullseye` image, as `bookworm` doesn't seem to be available yet on `mcr`
- install
  - `poetry`
  - `black`
  - `pre-commit`
  - `ruff`
  - `pylint`
  - `flake8`
 - install the dependencies
 - install the Git hooks
